### PR TITLE
후기 수정시 이미지 삭제 오류 수정 반영

### DIFF
--- a/src/main/java/com/dolphin/demo/service/CommentService.java
+++ b/src/main/java/com/dolphin/demo/service/CommentService.java
@@ -152,6 +152,17 @@ public class CommentService {
         List<String> imageList = new ArrayList<>();
         // 새로 등록하는 이미지가 없는 경우
         if(multipartFile == null) {
+            for (CommentImage commentImage : image) {
+                if (!imageRequestDto.getExistUrlList().contains(commentImage.getImageUrl())) {
+                    // S3 저장소에서 삭제
+                    amazonS3Service.deleteFile(commentImage.getImageUrl().substring(commentImage.getImageUrl().lastIndexOf("/") + 1));
+                    // DB 이미지 삭제
+                    commentImageRepository.delete(commentImage);
+                }
+                else {
+                    imageList.add(commentImage.getImageUrl());
+                }
+            }
             return ResponseEntity.ok().body(CommentResponseDto.builder()
                     .comment_id(comment.getId())
                     .place_id(comment.getPlace().getId())
@@ -159,6 +170,7 @@ public class CommentService {
                     .nickname(comment.getMember().getNickname())
                     .title(comment.getTitle())
                     .content(comment.getContent())
+                    .imageList(imageList)
                     .star(comment.getStar())
                     .createdAt(comment.getCreatedAt())
                     .modifiedAt(comment.getModifiedAt())


### PR DESCRIPTION
기존 이미지가 있는 후기를 수정할 때,
이미지를 새로 등록하지 않고 기존 이미지를 삭제하는 경우에 기존 이미지가 삭제되지 않는 오류 수정
  - 이미지를 새로 등록하는 경우, 등록하지 않는 경우 두 가지 조건에서
  - 이미지를 새로 등록하지 않는 경우에 기존 이미지를 삭제하는 로직을 따로 구현하지 않아서 생긴 오류
  - 기존 이미지를 삭제하는 로직을 두 가지 조건 모두에 설정함으로써 해결